### PR TITLE
Add lint about unneeded mutually recursive types (Fix Kakadu#17)

### DIFF
--- a/src/main.ml
+++ b/src/main.ml
@@ -37,6 +37,7 @@ let typed_linters =
   ; (module String_concat_fold : LINT.TYPED)
   ; (module UntypedLints.GuardInsteadOfIf : LINT.TYPED)
   ; (module Tuple_matching : LINT.TYPED)
+  ; (module Mutually_rec_types : LINT.TYPED)
     (* *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** *)
   ]
 ;;

--- a/src/typed/Mutually_rec_types.ml
+++ b/src/typed/Mutually_rec_types.ml
@@ -1,0 +1,154 @@
+(** Copyright 2021-2023, Kakadu. *)
+
+(** SPDX-License-Identifier: LGPL-3.0-or-later *)
+
+open Base
+open Zanuda_core
+open Zanuda_core.Utils
+
+type input = Tast_iterator.iterator
+
+let lint_id = "mutually_rec_types"
+let lint_source = LINT.FPCourse
+let group = LINT.Style
+let level = LINT.Warn
+
+let documentation =
+  {|
+### What it does
+Using `and` where there is no mutual recursion is discouraged.
+
+#### Explanation
+The keyword `and` should be used only to declare mutually recursive types or functions.
+Incorrect use of `and` can lead to confusion.
+It's recommended to rewrite type declarations without `and` where mutual recursion is not required.
+|}
+  |> Stdlib.String.trim
+;;
+
+let describe_as_json () =
+  describe_as_clippy_json lint_id ~group ~level ~docs:documentation
+;;
+
+let msg ppf strct_items =
+  let decl_names =
+    let open Parsetree in
+    strct_items
+    |> List.concat_map ~f:(fun s ->
+         match s.pstr_desc with
+         | Pstr_type (_, decls) ->
+           List.map decls ~f:(fun d -> Format.asprintf "'%s'" d.ptype_name.txt)
+         | _ -> [])
+    |> String.concat ~sep:", "
+  in
+  Format.fprintf
+    ppf
+    "Unneeded mutual recursion detected in these type declarations. It's recommended to \
+     rewrite %s as follows:@ %a"
+    decl_names
+    Pprintast.structure
+    strct_items
+;;
+
+let report msg ~loc strct_items =
+  let module M = struct
+    let txt ppf () =
+      Utils.Report.txt ~loc ~filename:loc.Location.loc_start.pos_fname ppf msg strct_items
+    ;;
+
+    let rdjsonl ppf () =
+      RDJsonl.pp
+        ppf
+        ~filename:(Config.recover_filepath loc.Location.loc_start.pos_fname)
+        ~line:loc.Location.loc_start.pos_lnum
+        msg
+        strct_items
+    ;;
+  end
+  in
+  (module M : LINT.REPORTER)
+;;
+
+module SCC = Strongly_connected_components.Make (Ident)
+
+let run _ fallback =
+  let pat =
+    let open Tast_pattern in
+    core_typ (typ_constr __ drop)
+  in
+  let open Typedtree in
+  let open Tast_iterator in
+  { fallback with
+    type_declarations =
+      (fun self typ_decls ->
+        let _, decls = typ_decls in
+        let graph =
+          List.fold_left decls ~init:Ident.Map.empty ~f:(fun acc decl ->
+            let extrnl_typs = Queue.create () in
+            let cr_typ_it =
+              { default_iterator with
+                typ =
+                  (fun self cr_typ ->
+                    let loc = cr_typ.ctyp_loc in
+                    Tast_pattern.parse
+                      pat
+                      loc
+                      cr_typ
+                      (fun p () ->
+                        match p with
+                        | Path.Pident id
+                          when List.exists decls ~f:(fun d -> Ident.same d.typ_id id) ->
+                          Queue.enqueue extrnl_typs id
+                        | _ -> ())
+                      ~on_error:(fun _desc () -> default_iterator.typ self cr_typ)
+                      ())
+              }
+            in
+            cr_typ_it.type_declaration cr_typ_it decl;
+            let extrnl_typs = Ident.Set.of_list @@ Queue.to_list extrnl_typs in
+            Ident.Map.add decl.typ_id extrnl_typs acc)
+        in
+        let comps = SCC.connected_components_sorted_from_roots_to_leaf graph in
+        if Array.length comps > 1
+        then (
+          let first_dec = List.hd_exn decls in
+          let first_loc = first_dec.typ_loc in
+          let last_loc = (List.last_exn decls).typ_loc in
+          let loc = { first_loc with loc_end = last_loc.loc_end } in
+          let correct_strcts =
+            comps
+            |> Array.rev
+            |> Array.filter_map ~f:(function
+                 | SCC.No_loop id ->
+                   List.find_map decls ~f:(fun dec ->
+                     if Stdlib.(dec = first_dec)
+                     then None
+                     else if Ident.same id dec.typ_id
+                     then
+                       Some
+                         (Ast_helper.Str.type_
+                            Recursive
+                            [ Untypeast.(
+                                default_mapper.type_declaration default_mapper dec)
+                            ])
+                     else None)
+                 | Has_loop loop ->
+                   if List.mem loop first_dec.typ_id ~equal:Ident.same
+                   then None
+                   else (
+                     let mtly_decls =
+                       List.filter_map decls ~f:(fun dec ->
+                         if List.mem loop dec.typ_id ~equal:Ident.same
+                         then
+                           Some
+                             Untypeast.(
+                               default_mapper.type_declaration default_mapper dec)
+                         else None)
+                     in
+                     Some (Ast_helper.Str.type_ Recursive mtly_decls)))
+            |> Array.to_list
+          in
+          CollectedLints.add ~loc (report msg ~loc correct_strcts));
+        fallback.type_declarations self typ_decls)
+  }
+;;

--- a/src/typed/dune
+++ b/src/typed/dune
@@ -15,7 +15,8 @@
   String_concat
   String_concat_fold
   Ignore
-  Tuple_matching)
+  Tuple_matching
+  Mutually_rec_types)
  (preprocess
   (pps ppx_inline_test ppxlib.metaquot))
  (instrumentation

--- a/tests/typed/Mutually_rec_types.t/Mutually_rec_types.ml
+++ b/tests/typed/Mutually_rec_types.t/Mutually_rec_types.ml
@@ -1,0 +1,75 @@
+(* should give a lint *)
+module _ = struct
+  type t1 =
+  | A of
+      { a : t2
+      ; b : t3
+      }
+  and t2 = B of t3
+  and t3 = C of int
+
+  type t4 = D of t1
+end
+ 
+(* should NOT give a lint *)
+module _ = struct
+  type t1 = A of t2
+  and t2 = B of t1
+
+  type t3 = C of t1
+end
+
+(* should give a lint *)
+module _ = struct
+  type t1 = A of t2
+  and t2 = B of t1
+  and t3 = C of t1
+end
+
+(* should give a lint *)
+module _ = struct
+  type t1 = A of t2 * t3
+  and t2 = B of t1
+
+  and t3 = C of t4 * t6
+  and t4 = D of t3
+
+  and t5 = E of int * t6 * t7
+  and t6 =
+    | F of t5
+    | L of
+        { a : int
+        ; b : string
+        }
+    | K of int
+    | O of string
+
+  and t7 = G of string
+  and t8 = H of t7
+  and t9 = int
+end
+
+(* should give a lint *)
+module _ = struct
+  type mt1 =
+  | U of t5
+  | V of t2
+  | W of mt2
+
+  and mt2 =
+    | X of t3
+    | Y of mt1
+
+  and t1 = A of t2
+  and t2 = B of t3
+  and t3 = C of t4
+  and t4 = D of t5
+  and t5 = E of t6
+  and t6 = F of int
+end
+
+(* should give a lint*)
+module _ = struct
+  type nonrec a = A
+  and b = B
+end

--- a/tests/typed/Mutually_rec_types.t/dune
+++ b/tests/typed/Mutually_rec_types.t/dune
@@ -1,0 +1,9 @@
+(env
+ (_
+  (flags
+   (:standard -w -37-34 -warn-error -37-34))))
+
+(library
+ (name test_mutually_rec_types)
+ (wrapped false)
+ (modules Mutually_rec_types))

--- a/tests/typed/Mutually_rec_types.t/dune-project
+++ b/tests/typed/Mutually_rec_types.t/dune-project
@@ -1,0 +1,3 @@
+(lang dune 2.8)
+
+(cram enable)

--- a/tests/typed/Mutually_rec_types.t/run.t
+++ b/tests/typed/Mutually_rec_types.t/run.t
@@ -1,0 +1,82 @@
+  $ dune build
+  $ zanuda -no-check-filesystem -no-top_file_license -dir .  -ordjsonl /dev/null
+  File "Mutually_rec_types.ml", lines 3-9, characters 2-19:
+  3 | ..type t1 =
+  4 |   | A of
+  5 |       { a : t2
+  6 |       ; b : t3
+  7 |       }
+  8 |   and t2 = B of t3
+  9 |   and t3 = C of int
+  Alert zanuda-linter: Unneeded mutual recursion detected in these type declarations. It's recommended to rewrite 't3', 't2' as follows:
+                       type t3 =
+                         | C of int 
+                       type t2 =
+                         | B of t3 
+  File "Mutually_rec_types.ml", lines 24-26, characters 2-18:
+  24 | ..type t1 = A of t2
+  25 |   and t2 = B of t1
+  26 |   and t3 = C of t1
+  Alert zanuda-linter: Unneeded mutual recursion detected in these type declarations. It's recommended to rewrite 't3' as follows:
+                       type t3 =
+                         | C of t1 
+  File "Mutually_rec_types.ml", lines 31-49, characters 2-14:
+  31 | ..type t1 = A of t2 * t3
+  32 |   and t2 = B of t1
+  33 | 
+  34 |   and t3 = C of t4 * t6
+  35 |   and t4 = D of t3
+  ...
+  46 | 
+  47 |   and t7 = G of string
+  48 |   and t8 = H of t7
+  49 |   and t9 = int
+  Alert zanuda-linter: Unneeded mutual recursion detected in these type declarations. It's recommended to rewrite 't7', 't5', 't6', 't3', 't4', 't8', 't9' as follows:
+                       type t7 =
+                         | G of string 
+                       type t5 =
+                         | E of int * t6 * t7 
+                       and t6 =
+                         | F of t5 
+                         | L of {
+                         a: int ;
+                         b: string } 
+                         | K of int 
+                         | O of string 
+                       type t3 =
+                         | C of t4 * t6 
+                       and t4 =
+                         | D of t3 
+                       type t8 =
+                         | H of t7 
+                       type t9 = int
+  File "Mutually_rec_types.ml", lines 54-68, characters 2-19:
+  54 | ..type mt1 =
+  55 |   | U of t5
+  56 |   | V of t2
+  57 |   | W of mt2
+  58 | 
+  ...
+  65 |   and t3 = C of t4
+  66 |   and t4 = D of t5
+  67 |   and t5 = E of t6
+  68 |   and t6 = F of int
+  Alert zanuda-linter: Unneeded mutual recursion detected in these type declarations. It's recommended to rewrite 't6', 't5', 't4', 't3', 't2', 't1' as follows:
+                       type t6 =
+                         | F of int 
+                       type t5 =
+                         | E of t6 
+                       type t4 =
+                         | D of t5 
+                       type t3 =
+                         | C of t4 
+                       type t2 =
+                         | B of t3 
+                       type t1 =
+                         | A of t2 
+  File "Mutually_rec_types.ml", lines 73-74, characters 2-11:
+  73 | ..type nonrec a = A
+  74 |   and b = B
+  Alert zanuda-linter: Unneeded mutual recursion detected in these type declarations. It's recommended to rewrite 'b' as follows:
+                       type b =
+                         | B 


### PR DESCRIPTION
It's find unneeded mutually recursive type declarations and suggests correct ones.