### PR TITLE
Fix lint about list length comparisons

### DIFF
--- a/src/typed/List_length.ml
+++ b/src/typed/List_length.ml
@@ -78,7 +78,7 @@ let pat
   Tast_pattern.t
   =
   let open Tast_pattern in
-  let ops = [ ">=", "<=", 0; "<=", ">=", 0; ">", "<", 0; "=", "=", 0 ] in
+  let ops = [ ">=", "<=", 0; "<=", ">=", 0; ">", "<", 0; "<", ">", 0; "=", "=", 0 ] in
   let single (op, dualop, n) =
     let open Tast_pattern in
     (* TODO: understand difference between Stdlib and Stdlib! *)

--- a/tests/typed/list_len.t/list_len.ml
+++ b/tests/typed/list_len.t/list_len.ml
@@ -11,3 +11,5 @@ let __ xs = List.length xs > 0
 let __ xs =  0 < List.length xs
 
 let __ xs = 0 = List.length xs
+
+let __ xs = 0 > List.length xs

--- a/tests/typed/list_len.t/run.t
+++ b/tests/typed/list_len.t/run.t
@@ -1,5 +1,10 @@
   $ dune build
   $ zanuda  -no-check-filesystem -no-top_file_license -dir .  -ordjsonl /dev/null
+  File "list_len.ml", line 1, characters 12-30:
+  1 | let __ xs = List.length xs < 0
+                  ^^^^^^^^^^^^^^^^^^
+  Alert zanuda-linter: Bad measurement of a list (with non-negative size)
+  Between 'List.length xs' and '0'.
   File "list_len.ml", line 3, characters 12-31:
   3 | let __ xs = List.length xs <= 0
                   ^^^^^^^^^^^^^^^^^^^
@@ -27,6 +32,11 @@
   Between '0' and 'List.length xs'.
   File "list_len.ml", line 13, characters 12-30:
   13 | let __ xs = 0 = List.length xs
+                   ^^^^^^^^^^^^^^^^^^
+  Alert zanuda-linter: Bad measurement of a list (with non-negative size)
+  Between '0' and 'List.length xs'.
+  File "list_len.ml", line 15, characters 12-30:
+  15 | let __ xs = 0 > List.length xs
                    ^^^^^^^^^^^^^^^^^^
   Alert zanuda-linter: Bad measurement of a list (with non-negative size)
   Between '0' and 'List.length xs'.


### PR DESCRIPTION
Now it also reports about `List.length xs < 0` and `0 > List.length xs`.