### PR TITLE
Fix lint about ambiguous constructors

### DIFF
--- a/src/typed/AmbiguousConstructors.ml
+++ b/src/typed/AmbiguousConstructors.ml
@@ -93,8 +93,8 @@ let run _ fallback =
               ctyp.ctyp_loc
               ctyp
               (fun p ->
-                match Ident.name (Path.head p) with
-                | "Stdlib" | "option" -> true
+                match Path.name p with
+                | "Stdlib.result" | "option" -> true
                 | _ -> false)
               ~on_error:(fun _ -> false)
         in


### PR DESCRIPTION
Now type path is obtained directly with `Path.name`, no exceptions thrown