### PR TITLE
Add lints about manual List.map/fold detection (fix #24)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,7 +16,7 @@
   (contributed by @Artem-Rzhankoff)
 - #32: Add lint about constructor names that hide default constructor names 
   (contributed by @nnemakin)
-- #34: Add lints that detects manual implementations of List.map/fold functions
+- #35: Add lints that detects manual implementations of List.map/fold functions
   (contributed by @nnemakin)
 
 ### Changed

--- a/CHANGES
+++ b/CHANGES
@@ -14,8 +14,10 @@
 - Expose library to parse DIFF format. It is available as 'zanuda.diff_parser' ocamlfind package.
 - #28: Add lint about nested if expressions.
   (contributed by @Artem-Rzhankoff)
-  #32: Add lint about constructor names that hide default constructor names (contributed by @nnemakin)
-
+- #32: Add lint about constructor names that hide default constructor names 
+  (contributed by @nnemakin)
+- #34: Add lints that detects manual implementations of List.map/fold functions
+  (contributed by @nnemakin)
 
 ### Changed
 

--- a/src/main.ml
+++ b/src/main.ml
@@ -12,6 +12,8 @@ let per_file_linters = [ (module UntypedLints.License : LINT.TYPED) ]
 let untyped_linters =
   let open UntypedLints in
   [ (module Casing : LINT.UNTYPED)
+  ; (module Manual_fold : LINT.UNTYPED)
+  ; (module Manual_map : LINT.UNTYPED)
   ; (module ParsetreeHasDocs : LINT.UNTYPED)
   ; (module UntypedLints.Propose_function : LINT.UNTYPED)
   ; (module ToplevelEval : LINT.UNTYPED)

--- a/src/untyped/Manual_fold.ml
+++ b/src/untyped/Manual_fold.ml
@@ -1,0 +1,184 @@
+(** Copyright 2021-2023, Kakadu. *)
+
+(** SPDX-License-Identifier: LGPL-3.0-or-later *)
+
+open Base
+open Caml.Format
+open Zanuda_core
+open Utils
+
+type input = Ast_iterator.iterator
+
+let lint_id = "manual_fold"
+let lint_source = LINT.Camelot
+let group = LINT.Style
+let level = LINT.Warn
+
+let documentation =
+  {|
+### What it does
+Proposes to use `List.fold_left` or `List.fold_right` instead of manual 
+implementations, such as:
+
+```ocaml
+  let rec fold_left f acc l = match l with
+  | [] -> acc
+  | x :: xs -> my_fold_left f (f acc a) l
+```
+
+### Why?
+It is too verbose and less perfomant.
+
+|}
+  |> Stdlib.String.trim
+;;
+
+let describe_as_json () =
+  describe_as_clippy_json lint_id ~impl:LINT.Untyped ~docs:documentation
+;;
+
+open Parsetree
+open Ast_iterator
+
+type kind =
+  | Fold_left
+  | Fold_right
+
+let msg ppf (kind, name) =
+  let s =
+    match kind with
+    | Fold_left -> "List.fold_left"
+    | Fold_right -> "List.fold_right"
+  in
+  Format.fprintf ppf "Consider using `%s` instead of `%s`%!" s name
+;;
+
+let report ~loc ~filename k n =
+  let module M = struct
+    let txt ppf () = Report.txt ~filename ~loc ppf msg (k, n)
+
+    let rdjsonl ppf () =
+      RDJsonl.pp
+        ppf
+        ~filename:(Config.recover_filepath loc.loc_start.pos_fname)
+        ~line:loc.loc_start.pos_lnum
+        msg
+        (k, n)
+    ;;
+  end
+  in
+  (module M : LINT.REPORTER)
+;;
+
+let has_arg x args =
+  List.exists
+    ~f:(fun (_, arg) ->
+      match arg.pexp_desc with
+      | Pexp_ident { txt = Lident a; _ } -> String.equal a x
+      | _ -> false)
+    args
+;;
+
+let is_fold fun_name tail f args =
+  if String.equal fun_name f && has_arg tail args
+  then Some Fold_left
+  else if List.exists
+            ~f:(fun (_, arg) ->
+              match arg.pexp_desc with
+              | Pexp_apply (exp, args) ->
+                (match exp.pexp_desc with
+                 | Pexp_ident { txt = Lident f; _ } ->
+                   String.equal fun_name f && has_arg tail args
+                 | _ -> false)
+              | _ -> false)
+            args
+  then Some Fold_right
+  else None
+;;
+
+let rec fun_body expr =
+  let result = expr in
+  match expr.pexp_desc with
+  | Pexp_fun (_, _, _, expr) -> fun_body expr
+  | _ -> result
+;;
+
+let run _ fallback =
+  let cases =
+    let open Ppxlib.Ast_pattern in
+    case
+      ~lhs:
+        (ppat_construct
+           (lident (string "::"))
+           (some (drop ** ppat_tuple (drop ^:: ppat_var __ ^:: nil))))
+      ~guard:none
+      ~rhs:(pexp_apply (pexp_ident (lident __)) __)
+    ^:: case
+          ~lhs:(ppat_construct (lident (string "[]")) drop)
+          ~guard:none
+          ~rhs:(pexp_ident (lident drop))
+    ^:: nil
+    ||| case
+          ~lhs:(ppat_construct (lident (string "[]")) drop)
+          ~guard:none
+          ~rhs:(pexp_ident (lident drop))
+        ^:: case
+              ~lhs:
+                (ppat_construct
+                   (lident (string "::"))
+                   (some (drop ** ppat_tuple (drop ^:: ppat_var __ ^:: nil))))
+              ~guard:none
+              ~rhs:(pexp_apply (pexp_ident (lident __)) __)
+        ^:: nil
+  in
+  let pat_main =
+    let open Ppxlib.Ast_pattern in
+    value_binding ~pat:(ppat_var __) ~expr:(pexp_fun drop drop drop __)
+  in
+  let pat_exp =
+    let open Ppxlib.Ast_pattern in
+    pexp_match drop cases ||| pexp_function cases
+  in
+  let parse vb =
+    let loc = vb.pvb_loc in
+    Ppxlib.Ast_pattern.parse
+      pat_main
+      loc
+      ~on_error:(fun _desc () -> ())
+      vb
+      (fun fun_name expr () ->
+        let body = fun_body expr in
+        Ppxlib.Ast_pattern.parse
+          pat_exp
+          body.pexp_loc
+          ~on_error:(fun _desc () -> ())
+          body
+          (fun tail f args () ->
+            match is_fold fun_name tail f args with
+            | Some kind ->
+              CollectedLints.add
+                ~loc
+                (report
+                   ~filename:loc.Location.loc_start.Lexing.pos_fname
+                   ~loc
+                   kind
+                   fun_name)
+            | None -> ())
+          ())
+      ()
+  in
+  { fallback with
+    structure_item =
+      (fun self si ->
+        fallback.structure_item self si;
+        match si.pstr_desc with
+        | Pstr_value (Asttypes.Recursive, vbl) -> List.iter vbl ~f:parse
+        | _ -> ())
+  ; expr =
+      (fun self e ->
+        fallback.expr self e;
+        match e.pexp_desc with
+        | Pexp_let (Asttypes.Recursive, vbl, _) -> List.iter vbl ~f:parse
+        | _ -> ())
+  }
+;;

--- a/src/untyped/Manual_map.ml
+++ b/src/untyped/Manual_map.ml
@@ -26,7 +26,7 @@ Proposes to use `List.map` instead of manual implementation, such as
 ```
 
 ### Why?
-It is too verbose and most likely less perfomant.
+It is too verbose and most likely less performant.
 
 |}
   |> Stdlib.String.trim
@@ -76,37 +76,25 @@ let run _ fallback =
   let pat =
     let open Ppxlib.Ast_pattern in
     let cases =
-      alt
-        (case
-           ~lhs:
-             (ppat_construct
-                (lident (string "::"))
-                (some (drop ** ppat_tuple (drop ^:: ppat_var __ ^:: nil))))
-           ~guard:none
-           ~rhs:
-             (pexp_construct
-                (lident (string "::"))
-                (some (pexp_tuple (drop ^:: pexp_apply __ __ ^:: nil))))
-         ^:: case
-               ~lhs:(ppat_construct (lident (string "[]")) drop)
-               ~guard:none
-               ~rhs:(pexp_construct (lident (string "[]")) drop)
-         ^:: nil)
-        (case
-           ~lhs:(ppat_construct (lident (string "[]")) drop)
-           ~guard:none
-           ~rhs:(pexp_construct (lident (string "[]")) drop)
-         ^:: case
-               ~lhs:
-                 (ppat_construct
-                    (lident (string "::"))
-                    (some (drop ** ppat_tuple (drop ^:: ppat_var __ ^:: nil))))
-               ~guard:none
-               ~rhs:
-                 (pexp_construct
-                    (lident (string "::"))
-                    (some (pexp_tuple (drop ^:: pexp_apply __ __ ^:: nil))))
-         ^:: nil)
+      let empty_case () =
+        case
+          ~lhs:(ppat_construct (lident (string "[]")) drop)
+          ~guard:none
+          ~rhs:(pexp_construct (lident (string "[]")) drop)
+      in
+      let cons_case () =
+        case
+          ~lhs:
+            (ppat_construct
+               (lident (string "::"))
+               (some (drop ** ppat_tuple (drop ^:: ppat_var __ ^:: nil))))
+          ~guard:none
+          ~rhs:
+            (pexp_construct
+               (lident (string "::"))
+               (some (pexp_tuple (drop ^:: pexp_apply __ __ ^:: nil))))
+      in
+      cons_case () ^:: empty_case () ^:: nil ||| empty_case () ^:: cons_case () ^:: nil
     in
     value_binding
       ~pat:(ppat_var __)

--- a/src/untyped/Manual_map.ml
+++ b/src/untyped/Manual_map.ml
@@ -1,0 +1,144 @@
+(** Copyright 2021-2023, Kakadu. *)
+
+(** SPDX-License-Identifier: LGPL-3.0-or-later *)
+
+open Base
+open Caml.Format
+open Zanuda_core
+open Utils
+
+type input = Ast_iterator.iterator
+
+let lint_id = "manual_map"
+let lint_source = LINT.Camelot
+let group = LINT.Style
+let level = LINT.Warn
+
+let documentation =
+  {|
+### What it does
+Proposes to use `List.map` instead of manual implementation, such as
+
+```ocaml
+  let rec map f = function
+  | [] -> []
+  | x :: xs -> f x :: map f xs
+```
+
+### Why?
+It is too verbose and most likely less perfomant.
+
+|}
+  |> Stdlib.String.trim
+;;
+
+let describe_as_json () =
+  describe_as_clippy_json lint_id ~impl:LINT.Untyped ~docs:documentation
+;;
+
+open Parsetree
+open Ast_iterator
+
+let msg ppf name = Format.fprintf ppf "Consider using `List.map` instead of `%s`%!" name
+
+let report ~loc ~filename name =
+  let module M = struct
+    let txt ppf () = Report.txt ~filename ~loc ppf msg name
+
+    let rdjsonl ppf () =
+      Report.rdjsonl
+        ~loc
+        ~filename:(Config.recover_filepath loc.loc_start.pos_fname)
+        ~code:lint_id
+        ppf
+        msg
+        name
+    ;;
+  end
+  in
+  (module M : LINT.REPORTER)
+;;
+
+let is_applied_to_tail fun_name tail f args =
+  match f.pexp_desc with
+  | Pexp_ident { txt = Lident f; _ } ->
+    String.equal f fun_name
+    && List.exists
+         ~f:(fun (_, arg) ->
+           match arg.pexp_desc with
+           | Pexp_ident { txt = Lident a; _ } -> String.equal a tail
+           | _ -> false)
+         args
+  | _ -> false
+;;
+
+let run _ fallback =
+  let pat =
+    let open Ppxlib.Ast_pattern in
+    let cases =
+      alt
+        (case
+           ~lhs:
+             (ppat_construct
+                (lident (string "::"))
+                (some (drop ** ppat_tuple (drop ^:: ppat_var __ ^:: nil))))
+           ~guard:none
+           ~rhs:
+             (pexp_construct
+                (lident (string "::"))
+                (some (pexp_tuple (drop ^:: pexp_apply __ __ ^:: nil))))
+         ^:: case
+               ~lhs:(ppat_construct (lident (string "[]")) drop)
+               ~guard:none
+               ~rhs:(pexp_construct (lident (string "[]")) drop)
+         ^:: nil)
+        (case
+           ~lhs:(ppat_construct (lident (string "[]")) drop)
+           ~guard:none
+           ~rhs:(pexp_construct (lident (string "[]")) drop)
+         ^:: case
+               ~lhs:
+                 (ppat_construct
+                    (lident (string "::"))
+                    (some (drop ** ppat_tuple (drop ^:: ppat_var __ ^:: nil))))
+               ~guard:none
+               ~rhs:
+                 (pexp_construct
+                    (lident (string "::"))
+                    (some (pexp_tuple (drop ^:: pexp_apply __ __ ^:: nil))))
+         ^:: nil)
+    in
+    value_binding
+      ~pat:(ppat_var __)
+      ~expr:(pexp_fun drop drop drop (pexp_function cases) ||| pexp_function cases)
+  in
+  let parse vb =
+    let loc = vb.pvb_loc in
+    Ppxlib.Ast_pattern.parse
+      pat
+      loc
+      ~on_error:(fun _desc () -> ())
+      vb
+      (fun fun_name tail f args () ->
+        if is_applied_to_tail fun_name tail f args
+        then
+          CollectedLints.add
+            ~loc
+            (report ~filename:loc.Location.loc_start.Lexing.pos_fname ~loc fun_name))
+      ()
+  in
+  { fallback with
+    structure_item =
+      (fun self si ->
+        fallback.structure_item self si;
+        match si.pstr_desc with
+        | Pstr_value (Asttypes.Recursive, vbl) -> List.iter vbl ~f:parse
+        | _ -> ())
+  ; expr =
+      (fun self e ->
+        fallback.expr self e;
+        match e.pexp_desc with
+        | Pexp_let (Asttypes.Recursive, vbl, _) -> List.iter vbl ~f:parse
+        | _ -> ())
+  }
+;;

--- a/src/untyped/dune
+++ b/src/untyped/dune
@@ -6,6 +6,8 @@
   GuardInsteadOfIf
   Dollar
   License
+  Manual_fold
+  Manual_map
   ParsetreeHasDocs
   Propose_function
   ToplevelEval

--- a/tests/untyped/manual_fold.t/dune
+++ b/tests/untyped/manual_fold.t/dune
@@ -1,0 +1,13 @@
+(library
+ (name test_manual_fold)
+ (wrapped false)
+ (modules manual_fold)
+ (instrumentation
+  (backend bisect_ppx))
+ (flags
+  (:standard
+   ;
+   )))
+
+(cram
+ (deps %{bin:zanuda.exe}))

--- a/tests/untyped/manual_fold.t/dune-project
+++ b/tests/untyped/manual_fold.t/dune-project
@@ -1,0 +1,3 @@
+(lang dune 2.8)
+
+(cram enable)

--- a/tests/untyped/manual_fold.t/manual_fold.ml
+++ b/tests/untyped/manual_fold.t/manual_fold.ml
@@ -1,0 +1,41 @@
+(* Should give a lint *)
+let rec fold_left f acc l =
+  match l with
+  | [] -> acc
+  | x :: xs -> fold_left f (f acc x) xs
+;;
+
+let rec fold_right f l acc =
+  match l with
+  | [] -> acc
+  | x :: xs -> f x (fold_right f xs acc)
+;;
+
+let f = (+);;
+
+let rec fold_right1 acc = function
+  | [] -> acc
+  | x :: xs -> f x (fold_right1 acc xs)
+;;
+
+let rec fold_left1 f acc l =
+  match l with
+  | [] -> acc
+  | x :: xs -> fold_left1 f (f acc x) xs
+;;
+
+let rec fold_right2 acc = function
+  | x :: xs -> f x (fold_right2 acc xs)
+  | [] -> acc
+;;
+
+let rec fold_left2 acc = function
+  | x :: xs -> fold_left2 (f acc x) xs
+  | [] -> acc
+;;
+
+let sum = 
+  let rec helper acc = function
+    | [] -> acc 
+    | x :: xs -> x + helper acc xs
+  in helper 0 

--- a/tests/untyped/manual_fold.t/run.t
+++ b/tests/untyped/manual_fold.t/run.t
@@ -1,0 +1,64 @@
+  $ dune build
+  $ zanuda  -no-check-filesystem -no-top_file_license -dir .  -ordjsonl /dev/null
+  File "manual_fold.ml", lines 2-5, characters 24-39:
+  2 | ........................l =
+  3 |   match l with
+  4 |   | [] -> acc
+  5 |   | x :: xs -> fold_left f (f acc x) xs
+  Alert zanuda-linter: Using `function` is recommended
+  File "manual_fold.ml", lines 2-5, characters 0-39:
+  2 | let rec fold_left f acc l =
+  3 |   match l with
+  4 |   | [] -> acc
+  5 |   | x :: xs -> fold_left f (f acc x) xs
+  Alert zanuda-linter: Consider using `List.fold_left` instead of `fold_left`
+  File "manual_fold.ml", lines 8-11, characters 0-40:
+   8 | let rec fold_right f l acc =
+   9 |   match l with
+  10 |   | [] -> acc
+  11 |   | x :: xs -> f x (fold_right f xs acc)
+  Alert zanuda-linter: Consider using `List.fold_right` instead of `fold_right`
+  File "manual_fold.ml", lines 16-18, characters 0-39:
+  16 | let rec fold_right1 acc = function
+  17 |   | [] -> acc
+  18 |   | x :: xs -> f x (fold_right1 acc xs)
+  Alert zanuda-linter: Consider using `List.fold_right` instead of `fold_right1`
+  File "manual_fold.ml", lines 21-24, characters 25-40:
+  21 | .........................l =
+  22 |   match l with
+  23 |   | [] -> acc
+  24 |   | x :: xs -> fold_left1 f (f acc x) xs
+  Alert zanuda-linter: Using `function` is recommended
+  File "manual_fold.ml", lines 21-24, characters 0-40:
+  21 | let rec fold_left1 f acc l =
+  22 |   match l with
+  23 |   | [] -> acc
+  24 |   | x :: xs -> fold_left1 f (f acc x) xs
+  Alert zanuda-linter: Consider using `List.fold_left` instead of `fold_left1`
+  File "manual_fold.ml", lines 27-29, characters 0-13:
+  27 | let rec fold_right2 acc = function
+  28 |   | x :: xs -> f x (fold_right2 acc xs)
+  29 |   | [] -> acc
+  Alert zanuda-linter: Consider using `List.fold_right` instead of `fold_right2`
+  File "manual_fold.ml", lines 32-34, characters 0-13:
+  32 | let rec fold_left2 acc = function
+  33 |   | x :: xs -> fold_left2 (f acc x) xs
+  34 |   | [] -> acc
+  Alert zanuda-linter: Consider using `List.fold_left` instead of `fold_left2`
+  File "manual_fold.ml", lines 38-40, characters 2-34:
+  38 | ..let rec helper acc = function
+  39 |     | [] -> acc 
+  40 |     | x :: xs -> x + helper acc xs
+  Alert zanuda-linter: Consider using `List.fold_right` instead of `helper`
+  File "manual_fold.ml", lines 2-5, characters 24-39:
+  2 | ........................l =
+  3 |   match l with
+  4 |   | [] -> acc
+  5 |   | x :: xs -> fold_left f (f acc x) xs
+  Alert zanuda-linter: Using `function` is recommended
+  File "manual_fold.ml", lines 21-24, characters 25-40:
+  21 | .........................l =
+  22 |   match l with
+  23 |   | [] -> acc
+  24 |   | x :: xs -> fold_left1 f (f acc x) xs
+  Alert zanuda-linter: Using `function` is recommended

--- a/tests/untyped/manual_fold.t/run.t
+++ b/tests/untyped/manual_fold.t/run.t
@@ -1,11 +1,5 @@
   $ dune build
-  $ zanuda  -no-check-filesystem -no-top_file_license -dir .  -ordjsonl /dev/null
-  File "manual_fold.ml", lines 2-5, characters 24-39:
-  2 | ........................l =
-  3 |   match l with
-  4 |   | [] -> acc
-  5 |   | x :: xs -> fold_left f (f acc x) xs
-  Alert zanuda-linter: Using `function` is recommended
+  $ zanuda  -no-check-filesystem -no-top_file_license -no-propose_function_untyped -no-propose_function -dir .  -ordjsonl /dev/null
   File "manual_fold.ml", lines 2-5, characters 0-39:
   2 | let rec fold_left f acc l =
   3 |   match l with
@@ -23,12 +17,6 @@
   17 |   | [] -> acc
   18 |   | x :: xs -> f x (fold_right1 acc xs)
   Alert zanuda-linter: Consider using `List.fold_right` instead of `fold_right1`
-  File "manual_fold.ml", lines 21-24, characters 25-40:
-  21 | .........................l =
-  22 |   match l with
-  23 |   | [] -> acc
-  24 |   | x :: xs -> fold_left1 f (f acc x) xs
-  Alert zanuda-linter: Using `function` is recommended
   File "manual_fold.ml", lines 21-24, characters 0-40:
   21 | let rec fold_left1 f acc l =
   22 |   match l with
@@ -50,15 +38,3 @@
   39 |     | [] -> acc 
   40 |     | x :: xs -> x + helper acc xs
   Alert zanuda-linter: Consider using `List.fold_right` instead of `helper`
-  File "manual_fold.ml", lines 2-5, characters 24-39:
-  2 | ........................l =
-  3 |   match l with
-  4 |   | [] -> acc
-  5 |   | x :: xs -> fold_left f (f acc x) xs
-  Alert zanuda-linter: Using `function` is recommended
-  File "manual_fold.ml", lines 21-24, characters 25-40:
-  21 | .........................l =
-  22 |   match l with
-  23 |   | [] -> acc
-  24 |   | x :: xs -> fold_left1 f (f acc x) xs
-  Alert zanuda-linter: Using `function` is recommended

--- a/tests/untyped/manual_map.t/dune
+++ b/tests/untyped/manual_map.t/dune
@@ -1,0 +1,13 @@
+(library
+ (name test_manual_map)
+ (wrapped false)
+ (modules manual_map)
+ (instrumentation
+  (backend bisect_ppx))
+ (flags
+  (:standard
+   ;
+   )))
+
+(cram
+ (deps %{bin:zanuda.exe}))

--- a/tests/untyped/manual_map.t/dune-project
+++ b/tests/untyped/manual_map.t/dune-project
@@ -1,0 +1,3 @@
+(lang dune 2.8)
+
+(cram enable)

--- a/tests/untyped/manual_map.t/manual_map.ml
+++ b/tests/untyped/manual_map.t/manual_map.ml
@@ -1,0 +1,32 @@
+(* Should give a lint *)
+let rec map1 f = function 
+  | [] -> []
+  | h :: tl -> f h :: map1 f tl
+;;
+
+let rec map2 f = function 
+  | x :: xs -> f x :: map2 f xs
+  | [] -> []
+;;
+
+let rec map3 = function 
+  | [] -> []
+  | h :: tl -> h + 1 :: map3 tl
+;;
+let rec map4 f l = match l with
+  | [] -> []
+  | x :: xs -> f x :: map4 f xs
+;;
+
+let rec map5 l f = match l with
+  | [] -> []
+  | x :: xs -> f x :: map5 xs f
+;;
+
+let concat input = 
+  let rec map = function
+    | x :: xs -> Int.to_string x :: map xs
+    | [] -> []
+  in
+  map input
+;;

--- a/tests/untyped/manual_map.t/run.t
+++ b/tests/untyped/manual_map.t/run.t
@@ -1,5 +1,5 @@
   $ dune build
-  $ zanuda  -no-check-filesystem -no-top_file_license -dir .  -ordjsonl /dev/null
+  $ zanuda  -no-check-filesystem -no-top_file_license -no-propose_function_untyped -no-propose_function -dir .  -ordjsonl /dev/null
   File "manual_map.ml", lines 2-4, characters 0-31:
   2 | let rec map1 f = function 
   3 |   | [] -> []
@@ -15,18 +15,8 @@
   13 |   | [] -> []
   14 |   | h :: tl -> h + 1 :: map3 tl
   Alert zanuda-linter: Consider using `List.map` instead of `map3`
-  File "manual_map.ml", lines 16-18, characters 15-31:
-  16 | ...............l = match l with
-  17 |   | [] -> []
-  18 |   | x :: xs -> f x :: map4 f xs
-  Alert zanuda-linter: Using `function` is recommended
   File "manual_map.ml", lines 27-29, characters 2-14:
   27 | ..let rec map = function
   28 |     | x :: xs -> Int.to_string x :: map xs
   29 |     | [] -> []
   Alert zanuda-linter: Consider using `List.map` instead of `map`
-  File "manual_map.ml", lines 16-18, characters 15-31:
-  16 | ...............l = match l with
-  17 |   | [] -> []
-  18 |   | x :: xs -> f x :: map4 f xs
-  Alert zanuda-linter: Using `function` is recommended

--- a/tests/untyped/manual_map.t/run.t
+++ b/tests/untyped/manual_map.t/run.t
@@ -1,0 +1,32 @@
+  $ dune build
+  $ zanuda  -no-check-filesystem -no-top_file_license -dir .  -ordjsonl /dev/null
+  File "manual_map.ml", lines 2-4, characters 0-31:
+  2 | let rec map1 f = function 
+  3 |   | [] -> []
+  4 |   | h :: tl -> f h :: map1 f tl
+  Alert zanuda-linter: Consider using `List.map` instead of `map1`
+  File "manual_map.ml", lines 7-9, characters 0-12:
+  7 | let rec map2 f = function 
+  8 |   | x :: xs -> f x :: map2 f xs
+  9 |   | [] -> []
+  Alert zanuda-linter: Consider using `List.map` instead of `map2`
+  File "manual_map.ml", lines 12-14, characters 0-31:
+  12 | let rec map3 = function 
+  13 |   | [] -> []
+  14 |   | h :: tl -> h + 1 :: map3 tl
+  Alert zanuda-linter: Consider using `List.map` instead of `map3`
+  File "manual_map.ml", lines 16-18, characters 15-31:
+  16 | ...............l = match l with
+  17 |   | [] -> []
+  18 |   | x :: xs -> f x :: map4 f xs
+  Alert zanuda-linter: Using `function` is recommended
+  File "manual_map.ml", lines 27-29, characters 2-14:
+  27 | ..let rec map = function
+  28 |     | x :: xs -> Int.to_string x :: map xs
+  29 |     | [] -> []
+  Alert zanuda-linter: Consider using `List.map` instead of `map`
+  File "manual_map.ml", lines 16-18, characters 15-31:
+  16 | ...............l = match l with
+  17 |   | [] -> []
+  18 |   | x :: xs -> f x :: map4 f xs
+  Alert zanuda-linter: Using `function` is recommended


### PR DESCRIPTION
It detects manually implemented versions of `List.map`/`List.fold_left`/`List.fold_right` functions and suggests to choose ones from `Stdlib`