### PR TITLE
Fix generation of fix_gen directory

### DIFF
--- a/src/fix/replacement/log.ml
+++ b/src/fix/replacement/log.ml
@@ -39,7 +39,7 @@ let rec rm path =
   | false -> Sys.remove path
 ;;
 
-let prepare_env =
+let prepare_env () =
   if Sys.file_exists fix_dir then rm fix_dir;
   Sys.mkdir fix_dir 0o755;
   create_file promote_script;

--- a/src/fix/replacement/refill.ml
+++ b/src/fix/replacement/refill.ml
@@ -76,7 +76,7 @@ let apply_all repls fcontent =
 open Log
 
 let apply_all _ =
-  prepare_env;
+  let () = prepare_env () in
   let new_payloads =
     FileRepl.fold
       (fun fname frepls fr_acc ->


### PR DESCRIPTION
The `fix_gen` directory was created independently of the options. 
For instance,
```sh
dune exec -- zanuda --help
```
It will generate a `fix_gen`.