### PR TITLE
README: update fantazio's link

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This linter is inspired by:
 * My experience in teaching OCaml at my local university.
 
 But I'm aware that there are other linters like [Camelot](https://github.com/upenn-cis1xx/camelot) for OCaml and [Clippy](https://github.com/rust-lang/rust-clippy) Rust.
-Two useful surveys should be mentioned too: [Simmo Saan's 2024](https://sim642.eu/blog/2024/05/01/ocaml-linting) and [fantazio's 2026](https://fantazio.eu/about.html).
+Two useful surveys should be mentioned too: [Simmo Saan's 2024](https://sim642.eu/blog/2024/05/01/ocaml-linting) and [fantazio's 2026](https://fantazio.eu/articles/static_analysis_ocaml.html).
 
 ##### Usage
 


### PR DESCRIPTION
It was pointing to the about page but I think it was meant to point to the "Static Analysis for OCaml" blog post